### PR TITLE
Update the links to regex's docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -83,7 +83,7 @@ if (window.location.href.match(/^http:\/\/rustexp.lpil.uk/)) {
         </ul>
         <p class="reference__more">
           For more information see the
-          <a href="https://doc.rust-lang.org/regex/regex/" target="_blank">
+          <a href="https://docs.rs/regex/" target="_blank">
             documentation for the regex crate
           </a>.
         </p>

--- a/static/index.html
+++ b/static/index.html
@@ -83,7 +83,7 @@ if (window.location.href.match(/^http:\/\/rustexp.lpil.uk/)) {
         </ul>
         <p class="reference__more">
           For more information see the
-          <a href="https://doc.rust-lang.org/regex/regex/" target="_blank">
+          <a href="https://docs.rs/regex/" target="_blank">
             documentation for the regex crate
           </a>.
         </p>


### PR DESCRIPTION
It's on docs.rs now and the redirect doesn't quite work for some reason :-/ so just update it to go to docs.rs directly!

(ps i love love love love love this project!)