### PR TITLE
Fix accidental duplicate to be the negative version

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -50,7 +50,7 @@ if (window.location.href.match(/^http:\/\/rustexp.lpil.uk/)) {
           <li><code>^</code> start of line</li>
           <li><code>$</code> end of line</li>
           <li><code>\b</code> word boundary</li>
-          <li><code>\b</code> word boundary</li>
+          <li><code>\B</code> non-word boundary</li>
           <li><code>\A</code> start of subject</li>
           <li><code>\z</code> end of subject</li>
           <li><code>\d</code> decimal digit</li>

--- a/static/index.html
+++ b/static/index.html
@@ -50,7 +50,7 @@ if (window.location.href.match(/^http:\/\/rustexp.lpil.uk/)) {
           <li><code>^</code> start of line</li>
           <li><code>$</code> end of line</li>
           <li><code>\b</code> word boundary</li>
-          <li><code>\b</code> word boundary</li>
+          <li><code>\B</code> non-word boundary</li>
           <li><code>\A</code> start of subject</li>
           <li><code>\z</code> end of subject</li>
           <li><code>\d</code> decimal digit</li>


### PR DESCRIPTION
`\b` was listed twice, I guessed that it was supposed to be `\B`, the negation of `\b`? I could also see just removing this entry, or replacing it with something else, I'm happy to make modifications if you'd like :)