### PR TITLE
Upgrade to the latest regex crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "once_cell"
@@ -98,9 +98,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -109,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustexp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 fancy-regex = "0.11"
-regex = "1.7"
+regex = "1.10.2"
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = [
     "Document",


### PR DESCRIPTION
Thank you so much for awesome tool :)
I noticed some newly supported grammars in the latest Regex crate, so I created a PR. 

## What Changed
Upgrade regex create version from [1.7.0 (2022-11-05)](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#170-2022-11-05) to [1.10.2 (2023-10-16)](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#1102-2023-10-16) .

There are several new grammars supported in recent releases. for example:
[1.8.0 (2023-04-20)](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#180-2023-04-20)
- https://github.com/rust-lang/regex/issues/501
- [Regex code example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b8e1adef0655e31be2473e05a1e56472)

[1.10.0 (2023-10-09)](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#1100-2023-10-09)
- https://github.com/rust-lang/regex/issues/469
- [Regex code example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=0561ce7cdfdfc9e123bfb7b0eaa3c015)

## Evidence
I confirmed that the compilation is successful.
```
fukusuke@fukusukenoAir rustexp % cargo -V
cargo 1.73.0 (9c4383fb5 2023-08-26)

fukusuke@fukusukenoAir rustexp % rustup -V
rustup 1.26.0 (5af9b9484 2023-04-05)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.73.0 (cc66ad468 2023-10-03)`

fukusuke@fukusukenoAir rustexp % cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.06s
     Running unittests src/main.rs (target/debug/deps/rustexp-1dd5bea5b58d4f9e)

running 5 tests
test tests::test_format_captures_no_matches ... ok
test tests::test_format_captures_no_captures ... ok
test tests::test_format_captures_all ... ok
test tests::test_format_captures_some ... ok
test tests::test_format_captures_some_2 ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

fukusuke@fukusukenoAir rustexp % trunk build --release
2023-10-29T06:01:13.938094Z  INFO 📦 starting build
2023-10-29T06:01:13.938668Z  INFO spawning asset pipelines
2023-10-29T06:01:14.004588Z  INFO building rustexp
2023-10-29T06:01:14.004601Z  INFO copying & hashing css path="main.css"
2023-10-29T06:01:14.004602Z  INFO copying & hashing icon path="favicon.ico"
2023-10-29T06:01:14.004948Z  INFO finished copying & hashing css path="main.css"
2023-10-29T06:01:14.005039Z  INFO finished copying & hashing icon path="favicon.ico"
    Finished release [optimized] target(s) in 0.02s
2023-10-29T06:01:14.063074Z  INFO fetching cargo artifacts
2023-10-29T06:01:14.108333Z  INFO processing WASM for rustexp
2023-10-29T06:01:14.109817Z  INFO calling wasm-bindgen for rustexp
2023-10-29T06:01:14.150808Z  INFO copying generated wasm-bindgen artifacts
2023-10-29T06:01:14.151745Z  INFO applying new distribution
2023-10-29T06:01:14.153404Z  INFO ✅ success
```